### PR TITLE
Another rewrite round, transitioning to objects

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,22 @@
+[flake8]
+max-line-length = 79
+application-import-names = culturgen
+type-checking-exempt-modules = typing
+import-order-style = google
+ignore =
+    # Line length limit. Acceptable (for now).
+    E501,
+    # Newline before binary operator. Sometimes this is more readable, e.g. in
+    # long arithmetic expressions.
+    W503,
+    # Newline after binary operator. Ignored by default (which we want to keep)
+    W504,
+    # These are forbidding certain __future__ imports. The future-import plugin
+    # has errors both for having and not having them; we want to have these until
+    # Python versions that require them are no longer supported.
+    FI58,
+    # These would require future imports that are not needed any more on py3.8
+    FI10,FI11,FI12,FI13,FI14,FI15,FI16,FI17,
+    # We use postponed annotation evaluation
+    TC2,
+no-accept-encodings = True

--- a/culturgen/__init__.py
+++ b/culturgen/__init__.py
@@ -25,6 +25,7 @@ def search_meme(
     :param user_agent: Optional custom user agent string to use in the headers.
     :return: A :class:`~.types.Meme` object representing the meme page, or
              ``None`` if no close enough result was found.
+    :raises ValueError: If ``threshold`` is outside the valid range.
     """
     if not (results := util.title_search(text, user_agent=user_agent)):
         return None
@@ -32,6 +33,9 @@ def search_meme(
     if threshold is None:
         # without a similarity threshold, just take the generator's first item
         return Meme(next(results).url)
+
+    if threshold < 0.0 or threshold > 1.0:
+        raise ValueError('threshold must be in the range [0.0, 1.0]')
 
     # this is where it gets interesting
     ranked = sorted(

--- a/culturgen/__init__.py
+++ b/culturgen/__init__.py
@@ -21,7 +21,7 @@ def search_meme(
 
     :param text: The text to search for in the Know Your Meme database.
     :param threshold: Optional similarity threshold for a match to be considered
-                      successful. Passed to :class:`difflib.SequenceMatcher`\\.
+                      successful. Valid range of 0.0 to 1.0, inclusive.
     :param user_agent: Optional custom user agent string to use in the headers.
     :return: A :class:`~.types.Meme` object representing the meme page, or
              ``None`` if no close enough result was found.
@@ -47,14 +47,15 @@ def search_meme(
 def search(
     text: str,
     *,  # keyword-only after this point
-    threshold: float | None = 0.4,
+    threshold: float | None = 0.5,
     user_agent: str | None = None,
 ) -> str | None:
     """Return a meme definition from keywords.
 
     :param text: The text to search for in the Know Your Meme database.
-    :param threshold: Optional similarity threshold for title matches. Defaults
-                      to ``0.4``; pass ``threshold=None`` to disable.
+    :param threshold: Optional similarity threshold for title matches. Valid
+                      range of 0.0 to 1.0, inclusive. Defaults to ``0.5``; pass
+                      ``threshold=None`` to disable.
     """
     if (meme := search_meme(
         text,

--- a/culturgen/types.py
+++ b/culturgen/types.py
@@ -1,0 +1,87 @@
+"""Custom data types for the culturgen library.
+
+Copyright (c) 2025 dgw
+
+MIT License
+"""
+from __future__ import annotations
+
+from collections import namedtuple
+
+from . import util
+
+
+TitleResult = namedtuple('TitleResult', ('title', 'url', 'ratio'))
+"""A simple title-search result object.
+
+:param title: The title of the search result.
+:param url: The URL of the search result.
+:param ratio: The similarity of the search result to the original query, as a
+              float between 0 and 1.
+"""
+
+
+class Meme:
+    """Object representing a meme entry on KYM.
+
+    :param url: The URL or slug of the meme page to represent.
+    :param user_agent: Optional custom user agent string to send when fetching
+                       the page from KYM.
+    :raises ValueError: If the meme page could not be fetched to instantiate the
+                        new object.
+
+    On object creation, fetches the meme page from Know Your Meme. Properties
+    are lazily extracted from the HTML when first accessed.
+    """
+    def __init__(
+        self,
+        url: str,
+        *,
+        user_agent: str | None = None,
+    ):
+        self._url = (
+            url if url.startswith(('http:', 'https:'))
+            else 'https://knowyourmeme.com/memes/' + url
+        )
+        page = util.get_meme_page(self._url, user_agent)
+        if page is None:
+            raise ValueError(f'Failed to fetch meme page at {self._url}')
+        self._page = page
+
+    @property
+    def url(self) -> str:
+        """The URL of the meme page."""
+        return self._url
+
+    @property
+    def title(self) -> str | None:
+        """The title of the meme.
+
+        Will be ``None`` if the title can't be extracted.
+        """
+        if not hasattr(self, '_title'):
+            self._title = util.get_meme_title(self._page)
+
+        return self._title or None
+
+    @property
+    def about(self) -> str | None:
+        """The "about" section of the meme page.
+
+        Returns the first string that can be found from the following list:
+
+        1. The text of the "about" section.
+        2. The first paragraph of the entry body.
+
+        Will be ``None`` if no text can be extracted.
+        """
+        if not hasattr(self, '_about'):
+            self._about = (
+                util.extract_section_text(self._page, 'about')
+                or getattr(self._page.select_one('#entry_body p'), 'text', None)
+            )
+
+        return self._about or None
+
+    def __repr__(self) -> str:
+        return f'<Meme: {self.title!r}>'

--- a/culturgen/util.py
+++ b/culturgen/util.py
@@ -1,8 +1,17 @@
 """Utility functions for the culturgen library."""
 from __future__ import annotations
 
+from difflib import SequenceMatcher
+import re
+from typing import TYPE_CHECKING
+
 from bs4 import BeautifulSoup
 import requests
+
+from .types import Meme, TitleResult
+
+if TYPE_CHECKING:
+    from typing import Generator
 
 
 DEFAULT_HEADERS = {
@@ -32,6 +41,21 @@ def get_headers(user_agent: str | None = None) -> dict[str, str]:
 
 
 def get_meme(
+    slug_or_url: str,
+    user_agent: str | None = None,
+) -> Meme:
+    """Get a meme object from its slug or URL.
+
+    :param slug_or_url: The slug or full KYM URL of the meme page to fetch.
+    :param user_agent: Optional custom user agent string to use in the headers.
+    :return: A :class:`~.types.Meme` object representing the meme page.
+    :raises ValueError: If the ``Meme`` object couldn't instantiate itself
+                        (probably because the given page doesn't exist).
+    """
+    return Meme(slug_or_url, user_agent=user_agent)
+
+
+def get_meme_page(
     slug_or_url: str,
     user_agent: str | None = None,
 ) -> BeautifulSoup | None:
@@ -107,16 +131,19 @@ def get_meme_title(soup: BeautifulSoup) -> str | None:
 def title_search(
     query: str,
     user_agent: str | None = None,
-) -> dict[str, str]:
+) -> Generator[TitleResult, None, None]:
     """Search Know Your Meme by title keywords.
 
     :param query: The search keyword(s).
     :param user_agent: Optional custom user agent string to use in the headers.
-    :return: A dictionary containing the title and URL of up to 10 results.
+    :return: An :term:`iterable` of up to 10 :class:`TitleResult` tuples.
 
     This function uses the "quick links" endpoint from KYM's search bar. On the
     one hand, that isn't a public API, so it could break at any time. On the
     other hand… HTML scraping can break too, if the page structure changes.
+
+    Results are filtered to only include standard meme pages (not under subpaths
+    like ``/memes/people/``).
     """
     r = requests.get(
         # uses http:// instead of https:// on purpose
@@ -127,15 +154,20 @@ def title_search(
             'query': query,
             'field': 'name',
             'fetch': 'name,url',
-            'len': 10,
+            'len': '10',
         },
     )
     try:
         data = r.json()
     except ValueError:
-        return {}
+        return
 
-    return {
-        item['name']: 'https://knowyourmeme.com' + item['url']
+    yield from (
+        TitleResult(
+            item['name'],
+            'https://knowyourmeme.com' + item['url'],
+            SequenceMatcher(None, query, item['name']).ratio(),
+        )
         for item in data['results']
-    }
+        if re.match(r'/memes/[^/]+/?$', item['url'], re.I)
+    )

--- a/culturgen/util.py
+++ b/culturgen/util.py
@@ -1,11 +1,11 @@
 """Utility functions for the culturgen library."""
 from __future__ import annotations
 
-from difflib import SequenceMatcher
 import re
 from typing import TYPE_CHECKING
 
 from bs4 import BeautifulSoup
+from jellyfish import jaro_winkler_similarity as jw_ratio
 import requests
 
 from .types import Meme, TitleResult
@@ -166,7 +166,10 @@ def title_search(
         TitleResult(
             item['name'],
             'https://knowyourmeme.com' + item['url'],
-            SequenceMatcher(None, query, item['name']).ratio(),
+            # .lower()ing both makes the similarity check case-insensitive,
+            # which is better for most use cases (e.g. users lazily typing
+            # queries in all lowercase)
+            jw_ratio(query.lower(), item['name'].lower()),
         )
         for item in data['results']
         if re.match(r'/memes/[^/]+/?$', item['url'], re.I)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "requests>=2.10",
     "beautifulsoup4>=4.5",
+    "jellyfish~=1.1",
+    "requests>=2.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = { file = ["README.md", "NEWS.md"], content-type = "text/markdown" }
 
 [project]
 name = "culturgen"
-version = "0.2.0"
+version = "0.3.0.dev0"
 description = "Know Your Meme scraper, a rewrite of memedict."
 authors = [
     { name = "dgw", email = "dgw@technobabbl.es" },


### PR DESCRIPTION
Along the way I think I fixed a few bugs, too, like sorting/ranking not working correctly if `threshold` was passed to `search_meme()`[1] and non-meme pages being returned by `title_search()`[2].

Overall this is a much bigger rewrite than I expected to be doing today, thanks to *I can't just leave that* syndrome.

It's good, though. The result is much closer to a coherent library API. Is it done? I doubt it. But I do like the `Meme` and `TitleResult` types created during this session.

The foundation for linting is also present here; I ran `flake8` and `mypy` against this revision of the code & fixed the errors raised before committing it, and added a `.flake8` config file based on another project (`sopel`). At some point those tools should make their way into a dev-requirements list, but we aren't there yet.

----

1. `title = max(filter(lambda k: scores[k] >= threshold, scores))` returned the "max" string, which was usually not the one with the highest similarity ratio. An obvious case was searching for 'boxxy' returned 'boxxy waves' or 'boxxy omegle troll' (depending whether the behavior was checked before or after I fixed [2]).

2. `title_search()` blindly accepted all URLs returned by the backend, even if they weren't meme pages. The search index contains pages under unhandled sub-paths like `/memes/people/` too, and those have to be filtered out.